### PR TITLE
Fix tried memory allocation bug

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -62,6 +62,11 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 16384 
+
 
   # Unnecesary for BNE deployment
   # pycsw:

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -62,6 +62,11 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 16384 
+
 
   # Unnecesary for BNE deployment
   # pycsw:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,11 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 16384 
+
 
   # Unnecesary for BNE deployment
   # pycsw:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose` configuration files to set ulimits for the `services:` section. The most important changes include adding the `ulimits` configuration with specified soft and hard limits for the `nofile` property.

Changes to `docker-compose` configuration:

* [`docker-compose.dev.yml`](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R65-R69): Added `ulimits` configuration with `nofile` soft limit of 8192 and hard limit of 16384.
* [`docker-compose.ghcr.yml`](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R65-R69): Added `ulimits` configuration with `nofile` soft limit of 8192 and hard limit of 16384.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R65-R69): Added `ulimits` configuration with `nofile` soft limit of 8192 and hard limit of 16384.

>[!NOTE]
> Info: https://github.com/sissbruecker/linkding/issues/439